### PR TITLE
Clang fix

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Build
         run: |
+          ninja -j1 std -C build # See https://github.com/llvm/llvm-project/commit/fc0e9c8315564288f9079a633892abadace534cf.
           ninja -C build
 
       - name: Run executable

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -3,7 +3,7 @@ name: Clang
 on:
   push:
     branches:
-      - main
+      - '**'
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -5,20 +5,6 @@
 
 Enable [C++23 standard library module feature, a.k.a. `import std` (P2465R3)](https://wg21.link/P2465R3) in your CMake (≥ 3.26) project.
 
-> [!IMPORTANT]
-> As of February 20, 2024, the Clang CI is currently experiencing failures. During the initial build, you may encounter the following error message, resulting in a build failure:
-> 
-> ```
-> fatal error: module file '/CppStandardLibraryModule/cmake-build-debug/_deps/std-build/CMakeFiles/std.dir/std.pcm' not found: module file not found
->    93 | export import std;
->       |        ^
-> 1 error generated.
-> [5/12] Scanning /CppStandardLibraryModule/cmake-build-debug/_deps/std-src/std.cppm for CXX dependencies
-> ninja: build stopped: subcommand failed.
-> ```
-> 
-> However, a subsequent build attempt is expected to succeed (re-enter the following command: `ninja -C build`). This issue appears to be related to module dependencies and can be resolved by retrying the build. If the problem persists, please let me know.
-
 ## How to do?
 
 There are prerequisites for using this repository.
@@ -100,8 +86,9 @@ After that, specify the CMake variable `LIBCXX_BUILD` to your custom module buil
 cd <your-project-dir>
 mkdir build
 CXX=clang++17 cmake -S . -B build -G Ninja -DLIBCXX_BUILD=<build-dir>
-ninja -C build # It might be failed at first time (see above), but it will be succeeded at second time.
-# Your executable will be at ./build
+ninja -j1 std -C build # For Clang, you must build std module first. See: https://github.com/llvm/llvm-project/commit/fc0e9c8315564288f9079a633892abadace534cf
+ninja -C build
+# Your executable will be at /build
 ```
 
 Here's [the GitHub CI code for Clang](https://github.com/stripe2933/CppStandardLibraryModule/blob/main/.github/workflows/clang.yml) for your insight.


### PR DESCRIPTION
This PR fixes Clang CI error that ninja dependency mismatch (`std` module must be built prior to the executable, but ninja is not able to configure it). See [This commit in LLVM repo](https://github.com/llvm/llvm-project/commit/fc0e9c8315564288f9079a633892abadace534cf) for detail. After this PR, CI got successful.