### PR TITLE
Use latest LLVM and cache libc++ build.

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -34,19 +34,28 @@ jobs:
           echo "CC=$(brew --prefix llvm)/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=$(brew --prefix llvm)/bin/clang++" >> "$GITHUB_ENV"
 
-      - name: Make local build of libc++ with module enabled
+      - name: Cache libc++ build
+        id: cache-libcxx
+        uses: actions/cache@v4
+        with:
+          path: llvm-project/build
+          key: ${{ runner.os }}-libcxx
+
+      - name: Make local build of libc++ with Standard Library Module (when cache miss)
+        if: steps.cache-libcxx.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/llvm/llvm-project.git
           cd llvm-project
           mkdir build
           cmake -G Ninja -S runtimes -B build                   \
-            -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind"
+            -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+            -DLLVM_INCLUDE_TESTS=OFF
           ninja -C build
 
       - name: Configure
         run: |
           mkdir build
-          cmake -S . -G Ninja -B build                              \
+          cmake -S . -G Ninja -B build                                \
             -DCMAKE_CXX_STANDARD=${{ matrix.std_version }}            \
             -DLIBCXX_BUILD=${{ github.workspace }}/llvm-project/build
 

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -28,34 +28,31 @@ jobs:
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
 
-      - name: Get LLVM 17 and Ninja via Homebrew
+      - name: Get LLVM and Ninja via Homebrew
         run: |
-          brew install llvm@17 ninja
+          brew install llvm ninja
+          echo "CC=$(brew --prefix llvm)/bin/clang" >> "$GITHUB_ENV"
+          echo "CXX=$(brew --prefix llvm)/bin/clang++" >> "$GITHUB_ENV"
 
       - name: Make local build of libc++ with module enabled
         run: |
           git clone https://github.com/llvm/llvm-project.git
           cd llvm-project
           mkdir build
-          CC=$(brew --prefix llvm@17)/bin/clang-17 \
-          CXX=$(brew --prefix llvm@17)/bin/clang++ \
-          cmake -G Ninja -S runtimes -B build \
+          cmake -G Ninja -S runtimes -B build                   \
             -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind"
           ninja -C build
-          cd ../
 
       - name: Configure
         run: |
           mkdir build
-          CC=$(brew --prefix llvm@17)/bin/clang-17 \
-          CXX=$(brew --prefix llvm@17)/bin/clang++ \
-          cmake -S . -G "Ninja" -B build \
-            -DCMAKE_CXX_STANDARD=${{ matrix.std_version }} \
+          cmake -S . -G Ninja -B build                              \
+            -DCMAKE_CXX_STANDARD=${{ matrix.std_version }}            \
             -DLIBCXX_BUILD=${{ github.workspace }}/llvm-project/build
 
       - name: Build
         run: |
-          ninja -C build
+          cmake --build build -t CppStandardLibraryModule --config Release
 
       - name: Run executable
         run: |

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build build --config Release -j4
+          cmake --build build -t CppStandardLibraryModule --config Release
 
       - name: Run executable
         run: |

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Configure
         run: |
           mkdir build
-          cmake -S . -B build `
-            -G "Visual Studio 17 2022" -T v143 `
+          cmake -S . -B build                              `
+            -G "Visual Studio 17 2022" -T v143             `
             -DCMAKE_CXX_STANDARD=${{ matrix.std_version }} `
             -DVCTOOLS_INSTALL_DIR="$env:VCToolsInstallDir"
 


### PR DESCRIPTION
This PR changes:
- Now Clang CI use latest Clang compiler from homebrew.
- Now Clang CI caches Libc++ build directory and use it if available. It solves long and inefficient clone-build time. Note that the cache is deleted after 7 days from its last usage, therefore weekly CI would not use this cache.